### PR TITLE
Safari layout bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,14 +4,15 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Daniel Moderiano is a full stack web developer comfortable building with React and Node.js."/>
+  <meta name="description"
+    content="Daniel Moderiano is a full stack web developer comfortable building with React and Node.js." />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel='canonical' href='https://danielmoderiano.com' />
   <link
     href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600&display=swap"
     rel="stylesheet">
-    <link rel="icon" href="./src/assets/icons/dm.svg"/>
+  <link rel="icon" href="./src/assets/icons/dm.svg" />
   <title>Daniel Moderiano | Web Developer</title>
 </head>
 
@@ -65,8 +66,7 @@
             </a>
           </li>
           <li class="mr-4 md:mr-5">
-            <a href="https://www.linkedin.com/in/daniel-moderiano-2a0429a9/" target="_blank"
-              rel="noopener noreferrer">
+            <a href="https://www.linkedin.com/in/daniel-moderiano-2a0429a9/" target="_blank" rel="noopener noreferrer">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" aria-hidden="true"
                 class="w-7 md:w-9 opacity-90 hover:opacity-100">
                 <path fill="#1F2937"
@@ -80,7 +80,8 @@
               class="underline hover:no-underline text-lg flex items-center justify-center font-semibold sm:text-xl xl:text-2xl text-gray-800"
               target="_blank" rel="noopener noreferrer">
               Resume
-              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 512 512" class="w-3 ml-1 mt-0.5 xl:w-4">
+              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 512 512"
+                class="w-3 ml-1 mt-0.5 xl:w-4">
                 <path fill="#1F2937"
                   d="M384 320c-17.67 0-32 14.33-32 32v96H64V160h96c17.67 0 32-14.32 32-32s-14.33-32-32-32L64 96c-35.35 0-64 28.65-64 64V448c0 35.34 28.65 64 64 64h288c35.35 0 64-28.66 64-64v-96C416 334.3 401.7 320 384 320zM488 0H352c-12.94 0-24.62 7.797-29.56 19.75c-4.969 11.97-2.219 25.72 6.938 34.88L370.8 96L169.4 297.4c-12.5 12.5-12.5 32.75 0 45.25C175.6 348.9 183.8 352 192 352s16.38-3.125 22.62-9.375L416 141.3l41.38 41.38c9.156 9.141 22.88 11.84 34.88 6.938C504.2 184.6 512 172.9 512 160V24C512 10.74 501.3 0 488 0z" />
               </svg>
@@ -144,7 +145,7 @@
               comments, and grow your friend network. Key features include image uploads, log in with Facebook,
               responsive
               design, and AI-assisted accessiblity.</p>
-      
+
 
             <!-- Project links -->
             <div class="flex items-center justify-start mb-5">
@@ -153,7 +154,8 @@
               <a class="text-lg underline hover:no-underline" href="https://odinbook-dm.herokuapp.com/" target="_blank"
                 rel="noopener noreferrer" aria-label="Visit Odinbook website">Visit website*</a>
             </div>
-            <p class="text-gray-700 text-sm mb-2">*Odinbook is hosted on Heroku, so please allow up to 30 seconds for the live website to load.</p>
+            <p class="text-gray-700 text-sm mb-2">*Odinbook is hosted on Heroku, so please allow up to 30 seconds for
+              the live website to load.</p>
           </div>
 
         </article>
@@ -171,8 +173,8 @@
 
         <section class="my-3 md:mt-5">
           <h3 class="font-light uppercase text-sm sm:text-base border-b mb-3 md:mb-4 w-32">Frontend</h3>
-          <ul class="flex flex-wrap gap-x-6 gap-y-0 md:gap-x-8">
-            <li class="flex flex-col items-center justify-center w-12 h-16">
+          <ul class="flex flex-wrap">
+            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mr-3 -ml-6">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-8 h-8" aria-hidden="true">
                 <path fill="#E34F26" d="M71,460 L30,0 481,0 440,460 255,512" />
                 <path fill="#EF652A" d="M256,472 L405,431 440,37 256,37" />
@@ -183,7 +185,7 @@
               </svg>
               <span class="text-xs md:text-sm mt-1">HTML</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16">
+            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-8 h-8" aria-hidden="true">
                 <path fill="#264de4" d="M71.357 460.819L30.272 0h451.456l-41.129 460.746L255.724 512z" />
                 <path fill="#2965f1" d="M405.388 431.408l35.148-393.73H256v435.146z" />
@@ -195,7 +197,7 @@
 
               <span class="text-xs md:text-sm mt-1">CSS</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16">
+            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 630 630" class="w-8 h-8" aria-hidden="true">
                 <rect width="630" height="630" fill="#f7df1e" />
                 <path
@@ -203,7 +205,7 @@
               </svg>
               <span class="text-xs md:text-sm mt-1">JavaScript</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16">
+            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29.43 29.43" class="w-8 h-8" aria-hidden="true">
                 <circle cx="14.71" cy="14.71" r="14.71" fill="#1f252d" />
                 <circle cx="14.71" cy="14.71" r="2.05" fill="#70cff0" />
@@ -215,8 +217,9 @@
               </svg>
               <span class="text-xs md:text-sm mt-1">React</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16">
-              <svg viewBox="0 0 1000 1000" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" aria-hidden="true">
+            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
+              <svg viewBox="0 0 1000 1000" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-8 h-8"
+                aria-hidden="true">
                 <path
                   d="M489.5 226.499C328 231.632 280 346.999 269 409.499C283.333 386.332 328.5 335.5 395 335.5C472.5 335.5 531.5 422 567.5 449C611.237 481.803 699.123 525.115 814.5 490C906.5 462 949.167 364.332 958.5 317.999C914 378.499 846.5 414.838 763 371.999C705.5 342.499 662.5 221 489.5 226.499Z"
                   fill="#38bdf8" />
@@ -226,7 +229,7 @@
               </svg>
               <span class="text-xs md:text-sm mt-1">Tailwind</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16">
+            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 774 875.7" class="w-8 h-8" aria-hidden="true">
                 <path fill="#FFF" d="M387 0l387 218.9v437.9L387 875.7 0 656.8V218.9z" />
                 <path fill="#8ed6fb"
@@ -242,22 +245,23 @@
         <section class="my-3 md:mt-5">
           <h3 class="font-light uppercase text-sm md:text-base border-b mb-3 md:mb-4 w-32">Backend</h3>
           <ul class="flex gap-x-6 md:gap-x-8">
-            <li class="flex flex-col items-center justify-center w-12 h-16">
+            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mr-3 -ml-6">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="w-8 h-8" aria-hidden="true">
                 <path fill="#689F63"
                   d="M224 508c-6.7 0-13.5-1.8-19.4-5.2l-61.7-36.5c-9.2-5.2-4.7-7-1.7-8 12.3-4.3 14.8-5.2 27.9-12.7 1.4-.8 3.2-.5 4.6.4l47.4 28.1c1.7 1 4.1 1 5.7 0l184.7-106.6c1.7-1 2.8-3 2.8-5V149.3c0-2.1-1.1-4-2.9-5.1L226.8 37.7c-1.7-1-4-1-5.7 0L36.6 144.3c-1.8 1-2.9 3-2.9 5.1v213.1c0 2 1.1 4 2.9 4.9l50.6 29.2c27.5 13.7 44.3-2.4 44.3-18.7V167.5c0-3 2.4-5.3 5.4-5.3h23.4c2.9 0 5.4 2.3 5.4 5.3V378c0 36.6-20 57.6-54.7 57.6-10.7 0-19.1 0-42.5-11.6l-48.4-27.9C8.1 389.2.7 376.3.7 362.4V149.3c0-13.8 7.4-26.8 19.4-33.7L204.6 9c11.7-6.6 27.2-6.6 38.8 0l184.7 106.7c12 6.9 19.4 19.8 19.4 33.7v213.1c0 13.8-7.4 26.7-19.4 33.7L243.4 502.8c-5.9 3.4-12.6 5.2-19.4 5.2zm149.1-210.1c0-39.9-27-50.5-83.7-58-57.4-7.6-63.2-11.5-63.2-24.9 0-11.1 4.9-25.9 47.4-25.9 37.9 0 51.9 8.2 57.7 33.8.5 2.4 2.7 4.2 5.2 4.2h24c1.5 0 2.9-.6 3.9-1.7s1.5-2.6 1.4-4.1c-3.7-44.1-33-64.6-92.2-64.6-52.7 0-84.1 22.2-84.1 59.5 0 40.4 31.3 51.6 81.8 56.6 60.5 5.9 65.2 14.8 65.2 26.7 0 20.6-16.6 29.4-55.5 29.4-48.9 0-59.6-12.3-63.2-36.6-.4-2.6-2.6-4.5-5.3-4.5h-23.9c-3 0-5.3 2.4-5.3 5.3 0 31.1 16.9 68.2 97.8 68.2 58.4-.1 92-23.2 92-63.4z" />
               </svg>
               <span class="text-xs md:text-sm mt-1">Node.js</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16">
-              <svg viewBox="0 0 52 30" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" aria-hidden="true">
+            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
+              <svg viewBox="0 0 52 30" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-8 h-8"
+                aria-hidden="true">
                 <path
                   d="M51.7026 29.1934C50.9501 29.478 50.1195 29.4774 49.3674 29.1917C48.6154 28.9059 47.9939 28.3548 47.6203 27.6424L40.188 17.3643L39.1109 15.9274L30.4873 27.6553C30.1361 28.3379 29.5484 28.8692 28.8339 29.1499C28.1195 29.4306 27.3272 29.4415 26.6053 29.1805L37.7171 14.2729L27.3808 0.806564C28.1241 0.538734 28.9369 0.535183 29.6824 0.79651C30.4279 1.05784 31.0606 1.56808 31.474 2.24131L39.1777 12.6465L46.9244 2.2844C47.2783 1.61396 47.8662 1.09693 48.5764 0.831615C49.2866 0.566296 50.0695 0.571181 50.7763 0.845341L46.765 6.16855L41.3319 13.241C41.181 13.3756 41.0603 13.5406 40.9776 13.7251C40.895 13.9096 40.8522 14.1095 40.8522 14.3117C40.8522 14.5139 40.895 14.7138 40.9776 14.8983C41.0603 15.0828 41.181 15.2478 41.3319 15.3824L51.6811 29.1956L51.7026 29.1934ZM0.00433439 14.0877L0.90913 9.61755C3.39516 0.77856 13.5289 -2.89879 20.5001 2.57307C24.5824 5.78078 25.6014 10.322 25.4011 15.4405H2.4042C2.03151 24.5811 8.62789 30.1004 17.0619 27.2804C18.4291 26.7883 19.6529 25.9647 20.6237 24.8834C21.5944 23.8021 22.2818 22.4969 22.6242 21.0847C23.0701 19.65 23.8048 19.4044 25.1533 19.818C24.9286 21.5681 24.3099 23.2445 23.3439 24.721C22.3778 26.1975 21.0895 27.4357 19.5759 28.3425C17.0757 29.7101 14.2071 30.2521 11.3802 29.8911C8.5534 29.5301 5.91307 28.2846 3.83679 26.3326C1.78383 24.0219 0.543067 21.103 0.303778 18.0214C0.303778 17.5151 0.131437 17.0412 0.0151058 16.5866C0.00461882 15.7544 -0.000407927 14.9221 2.58433e-05 14.0898L0.00433439 14.0877ZM2.4322 13.4715H23.2296C23.1003 6.845 18.9189 2.14437 13.3414 2.10128C7.13283 2.01511 2.69071 6.61233 2.41712 13.4414L2.4322 13.4715Z"
                   fill="#000000" />
               </svg>
               <span class="text-xs md:text-sm mt-1">Express</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16">
+            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 67" fill="#fff" fill-rule="evenodd" stroke="#000"
                 stroke-linecap="round" stroke-linejoin="round" class="w-8 h-8" aria-hidden="true">
                 <g stroke="none" fill-rule="nonzero">
@@ -274,7 +278,7 @@
               </svg>
               <span class="text-xs md:text-sm mt-1">MongoDB</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16">
+            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" class="w-8 h-8" aria-hidden="true">
                 <defs>
                   <linearGradient id="d" x1="-108.63" y1="-692.24" x2="-58.56" y2="-742.31"
@@ -325,7 +329,7 @@
         <section class="mt-3 md:mt-5">
           <h3 class="font-light uppercase text-sm md:text-base border-b mb-3 md:mb-4 w-32">General</h3>
           <ul class="flex gap-x-6 md:gap-x-8">
-            <li class="flex flex-col items-center justify-center w-12 h-16">
+            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mr-3 -ml-6">
               <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg"
                 xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 97 97"
                 enable-background="new 0 0 97 97" xml:space="preserve" class="w-8 h-8" aria-hidden="true">
@@ -341,7 +345,7 @@
               </svg>
               <span class="text-xs md:text-sm mt-1">Git</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16">
+            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 66" fill="#fff" fill-rule="evenodd" stroke="#000"
                 stroke-linecap="round" stroke-linejoin="round" class="w-8 h-8" aria-hidden="true">
                 <path

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
         <!-- OPTOMRX -->
         <article class="flex flex-col xl:flex-row">
           <img src="./src/assets/images/optomrx-small.png" alt="optomrx web app dashboard"
-            class="shadow-md rounded-lg xl:max-w-2xl">
+            class="shadow-md rounded-lg xl:max-w-2xl xl:max-h-[389px]">
           <div class="xl:flex xl:flex-col xl:ml-8">
             <h3 class="text-2xl font-semibold mt-4">OptomRx</h3>
 
@@ -130,7 +130,7 @@
         <!-- ODINBOOK -->
         <article class="mt-16 flex flex-col xl:flex-row">
           <img src="./src/assets/images/odinbook-small.png" alt="odinbook web app profile page"
-            class="shadow-md rounded-lg xl:max-w-2xl">
+            class="shadow-md rounded-lg xl:max-w-2xl xl:max-h-[389px]">
           <div class="xl:flex xl:flex-col xl:ml-8">
             <h3 class="text-2xl font-semibold mt-4">Odinbook</h3>
 

--- a/index.html
+++ b/index.html
@@ -173,8 +173,8 @@
 
         <section class="my-3 md:mt-5">
           <h3 class="font-light uppercase text-sm sm:text-base border-b mb-3 md:mb-4 w-32">Frontend</h3>
-          <ul class="flex flex-wrap">
-            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mr-3 -ml-6">
+          <ul class="flex flex-wrap pl-6 -mr-8">
+            <li class="flex flex-col items-center justify-center w-12 h-16 pr-[68px] md:pr-[74px]">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-8 h-8" aria-hidden="true">
                 <path fill="#E34F26" d="M71,460 L30,0 481,0 440,460 255,512" />
                 <path fill="#EF652A" d="M256,472 L405,431 440,37 256,37" />
@@ -185,7 +185,7 @@
               </svg>
               <span class="text-xs md:text-sm mt-1">HTML</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
+            <li class="flex flex-col items-center justify-center w-12 h-16 pr-[68px] md:pr-[74px]">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-8 h-8" aria-hidden="true">
                 <path fill="#264de4" d="M71.357 460.819L30.272 0h451.456l-41.129 460.746L255.724 512z" />
                 <path fill="#2965f1" d="M405.388 431.408l35.148-393.73H256v435.146z" />
@@ -197,7 +197,7 @@
 
               <span class="text-xs md:text-sm mt-1">CSS</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
+            <li class="flex flex-col items-center justify-center w-12 h-16 pr-[68px] md:pr-[74px]">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 630 630" class="w-8 h-8" aria-hidden="true">
                 <rect width="630" height="630" fill="#f7df1e" />
                 <path
@@ -205,7 +205,7 @@
               </svg>
               <span class="text-xs md:text-sm mt-1">JavaScript</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
+            <li class="flex flex-col items-center justify-center w-12 h-16 pr-[68px] md:pr-[74px]">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29.43 29.43" class="w-8 h-8" aria-hidden="true">
                 <circle cx="14.71" cy="14.71" r="14.71" fill="#1f252d" />
                 <circle cx="14.71" cy="14.71" r="2.05" fill="#70cff0" />
@@ -217,7 +217,7 @@
               </svg>
               <span class="text-xs md:text-sm mt-1">React</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
+            <li class="flex flex-col items-center justify-center w-12 h-16 pr-[68px] md:pr-[74px]">
               <svg viewBox="0 0 1000 1000" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-8 h-8"
                 aria-hidden="true">
                 <path
@@ -229,7 +229,7 @@
               </svg>
               <span class="text-xs md:text-sm mt-1">Tailwind</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
+            <li class="flex flex-col items-center justify-center w-12 h-16 pr-[68px] md:pr-[74px]">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 774 875.7" class="w-8 h-8" aria-hidden="true">
                 <path fill="#FFF" d="M387 0l387 218.9v437.9L387 875.7 0 656.8V218.9z" />
                 <path fill="#8ed6fb"
@@ -244,15 +244,15 @@
 
         <section class="my-3 md:mt-5">
           <h3 class="font-light uppercase text-sm md:text-base border-b mb-3 md:mb-4 w-32">Backend</h3>
-          <ul class="flex gap-x-6 md:gap-x-8">
-            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mr-3 -ml-6">
+          <ul class="flex flex-wrap pl-6 -mr-8">
+            <li class="flex flex-col items-center justify-center w-12 h-16 pr-[68px] md:pr-[74px]">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="w-8 h-8" aria-hidden="true">
                 <path fill="#689F63"
                   d="M224 508c-6.7 0-13.5-1.8-19.4-5.2l-61.7-36.5c-9.2-5.2-4.7-7-1.7-8 12.3-4.3 14.8-5.2 27.9-12.7 1.4-.8 3.2-.5 4.6.4l47.4 28.1c1.7 1 4.1 1 5.7 0l184.7-106.6c1.7-1 2.8-3 2.8-5V149.3c0-2.1-1.1-4-2.9-5.1L226.8 37.7c-1.7-1-4-1-5.7 0L36.6 144.3c-1.8 1-2.9 3-2.9 5.1v213.1c0 2 1.1 4 2.9 4.9l50.6 29.2c27.5 13.7 44.3-2.4 44.3-18.7V167.5c0-3 2.4-5.3 5.4-5.3h23.4c2.9 0 5.4 2.3 5.4 5.3V378c0 36.6-20 57.6-54.7 57.6-10.7 0-19.1 0-42.5-11.6l-48.4-27.9C8.1 389.2.7 376.3.7 362.4V149.3c0-13.8 7.4-26.8 19.4-33.7L204.6 9c11.7-6.6 27.2-6.6 38.8 0l184.7 106.7c12 6.9 19.4 19.8 19.4 33.7v213.1c0 13.8-7.4 26.7-19.4 33.7L243.4 502.8c-5.9 3.4-12.6 5.2-19.4 5.2zm149.1-210.1c0-39.9-27-50.5-83.7-58-57.4-7.6-63.2-11.5-63.2-24.9 0-11.1 4.9-25.9 47.4-25.9 37.9 0 51.9 8.2 57.7 33.8.5 2.4 2.7 4.2 5.2 4.2h24c1.5 0 2.9-.6 3.9-1.7s1.5-2.6 1.4-4.1c-3.7-44.1-33-64.6-92.2-64.6-52.7 0-84.1 22.2-84.1 59.5 0 40.4 31.3 51.6 81.8 56.6 60.5 5.9 65.2 14.8 65.2 26.7 0 20.6-16.6 29.4-55.5 29.4-48.9 0-59.6-12.3-63.2-36.6-.4-2.6-2.6-4.5-5.3-4.5h-23.9c-3 0-5.3 2.4-5.3 5.3 0 31.1 16.9 68.2 97.8 68.2 58.4-.1 92-23.2 92-63.4z" />
               </svg>
               <span class="text-xs md:text-sm mt-1">Node.js</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
+            <li class="flex flex-col items-center justify-center w-12 h-16 pr-[68px] md:pr-[74px]">
               <svg viewBox="0 0 52 30" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-8 h-8"
                 aria-hidden="true">
                 <path
@@ -261,7 +261,7 @@
               </svg>
               <span class="text-xs md:text-sm mt-1">Express</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
+            <li class="flex flex-col items-center justify-center w-12 h-16 pr-[68px] md:pr-[74px]">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 67" fill="#fff" fill-rule="evenodd" stroke="#000"
                 stroke-linecap="round" stroke-linejoin="round" class="w-8 h-8" aria-hidden="true">
                 <g stroke="none" fill-rule="nonzero">
@@ -278,7 +278,7 @@
               </svg>
               <span class="text-xs md:text-sm mt-1">MongoDB</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
+            <li class="flex flex-col items-center justify-center w-12 h-16 pr-[68px] md:pr-[74px]">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" class="w-8 h-8" aria-hidden="true">
                 <defs>
                   <linearGradient id="d" x1="-108.63" y1="-692.24" x2="-58.56" y2="-742.31"
@@ -328,8 +328,8 @@
 
         <section class="mt-3 md:mt-5">
           <h3 class="font-light uppercase text-sm md:text-base border-b mb-3 md:mb-4 w-32">General</h3>
-          <ul class="flex gap-x-6 md:gap-x-8">
-            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mr-3 -ml-6">
+          <ul class="flex flex-wrap pl-6 -mr-8">
+            <li class="flex flex-col items-center justify-center w-12 h-16 pr-[68px] md:pr-[74px]">
               <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg"
                 xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 97 97"
                 enable-background="new 0 0 97 97" xml:space="preserve" class="w-8 h-8" aria-hidden="true">
@@ -345,7 +345,7 @@
               </svg>
               <span class="text-xs md:text-sm mt-1">Git</span>
             </li>
-            <li class="flex flex-col items-center justify-center w-12 h-16 px-12 -mx-3">
+            <li class="flex flex-col items-center justify-center w-12 h-16 pr-[68px] md:pr-[74px]">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 66" fill="#fff" fill-rule="evenodd" stroke="#000"
                 stroke-linecap="round" stroke-linejoin="round" class="w-8 h-8" aria-hidden="true">
                 <path

--- a/src/styles/output.css
+++ b/src/styles/output.css
@@ -647,6 +647,34 @@ Ensure the default browser behavior of the `hidden` attribute.
   margin-right: -1.25rem;
 }
 
+.-mr-12 {
+  margin-right: -3rem;
+}
+
+.-mr-8 {
+  margin-right: -2rem;
+}
+
+.-mr-0 {
+  margin-right: -0px;
+}
+
+.-ml-12 {
+  margin-left: -3rem;
+}
+
+.-ml-2 {
+  margin-left: -0.5rem;
+}
+
+.-mr-2 {
+  margin-right: -0.5rem;
+}
+
+.-mr-10 {
+  margin-right: -2.5rem;
+}
+
 .flex {
   display: flex;
 }
@@ -841,6 +869,50 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .pl-2 {
   padding-left: 0.5rem;
+}
+
+.pr-12 {
+  padding-right: 3rem;
+}
+
+.pr-24 {
+  padding-right: 6rem;
+}
+
+.pl-12 {
+  padding-left: 3rem;
+}
+
+.pl-6 {
+  padding-left: 1.5rem;
+}
+
+.pr-20 {
+  padding-right: 5rem;
+}
+
+.pr-16 {
+  padding-right: 4rem;
+}
+
+.pr-\[68px\] {
+  padding-right: 68px;
+}
+
+.pr-0 {
+  padding-right: 0px;
+}
+
+.pr-\[30px\] {
+  padding-right: 30px;
+}
+
+.pl-\[68px\] {
+  padding-left: 68px;
+}
+
+.pr-\[12px\] {
+  padding-right: 12px;
 }
 
 .text-center {
@@ -1053,6 +1125,14 @@ Ensure the default browser behavior of the `hidden` attribute.
     margin-bottom: 1rem;
   }
 
+  .md\:-ml-8 {
+    margin-left: -2rem;
+  }
+
+  .md\:-ml-7 {
+    margin-left: -1.75rem;
+  }
+
   .md\:block {
     display: block;
   }
@@ -1085,12 +1165,49 @@ Ensure the default browser behavior of the `hidden` attribute.
     padding-right: 0.75rem;
   }
 
+  .md\:px-14 {
+    padding-left: 3.5rem;
+    padding-right: 3.5rem;
+  }
+
+  .md\:px-12 {
+    padding-left: 3rem;
+    padding-right: 3rem;
+  }
+
+  .md\:px-\[52px\] {
+    padding-left: 52px;
+    padding-right: 52px;
+  }
+
+  .md\:px-\[50px\] {
+    padding-left: 50px;
+    padding-right: 50px;
+  }
+
+  .md\:px-\[70px\] {
+    padding-left: 70px;
+    padding-right: 70px;
+  }
+
   .md\:pr-3 {
     padding-right: 0.75rem;
   }
 
   .md\:pl-3 {
     padding-left: 0.75rem;
+  }
+
+  .md\:pr-\[70px\] {
+    padding-right: 70px;
+  }
+
+  .md\:pr-\[72px\] {
+    padding-right: 72px;
+  }
+
+  .md\:pr-\[74px\] {
+    padding-right: 74px;
   }
 
   .md\:text-3xl {

--- a/src/styles/output.css
+++ b/src/styles/output.css
@@ -510,6 +510,31 @@ Ensure the default browser behavior of the `hidden` attribute.
   margin-bottom: 0.75rem;
 }
 
+.-mx-12 {
+  margin-left: -3rem;
+  margin-right: -3rem;
+}
+
+.-mx-6 {
+  margin-left: -1.5rem;
+  margin-right: -1.5rem;
+}
+
+.-mx-2 {
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+}
+
+.-mx-4 {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+
+.-mx-3 {
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+}
+
 .mt-32 {
   margin-top: 8rem;
 }
@@ -592,6 +617,34 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .mt-2 {
   margin-top: 0.5rem;
+}
+
+.-mr-3 {
+  margin-right: -0.75rem;
+}
+
+.-mr-4 {
+  margin-right: -1rem;
+}
+
+.-ml-6 {
+  margin-left: -1.5rem;
+}
+
+.-ml-8 {
+  margin-left: -2rem;
+}
+
+.-ml-7 {
+  margin-left: -1.75rem;
+}
+
+.-mr-6 {
+  margin-right: -1.5rem;
+}
+
+.-mr-5 {
+  margin-right: -1.25rem;
 }
 
 .flex {
@@ -770,6 +823,16 @@ Ensure the default browser behavior of the `hidden` attribute.
 .py-7 {
   padding-top: 1.75rem;
   padding-bottom: 1.75rem;
+}
+
+.px-12 {
+  padding-left: 3rem;
+  padding-right: 3rem;
+}
+
+.px-1 {
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
 }
 
 .pr-2 {

--- a/src/styles/output.css
+++ b/src/styles/output.css
@@ -1254,6 +1254,10 @@ Ensure the default browser behavior of the `hidden` attribute.
     display: flex;
   }
 
+  .xl\:max-h-\[389px\] {
+    max-height: 389px;
+  }
+
   .xl\:w-4 {
     width: 1rem;
   }


### PR DESCRIPTION
This PR addresses two layout/CSS bugs in older versions of safari, namely 
1. Flex-gap not applying to skills section
2. Image height not maintaining aspect ratio

These have been fixed with a reversion to padding instead of gap, and setting explicit max heights for images.